### PR TITLE
Non-exact matches now do not prioritize tokens over all other cards

### DIFF
--- a/card_lookup.py
+++ b/card_lookup.py
@@ -50,7 +50,7 @@ def process_card_lookup(matches):
                         non_exact_sql = non_exact_sql + " AND card_name LIKE ?"
 
                     # prioritize newer sets but don't prioritize tokens
-                    non_exact_sql = non_exact_sql + " ORDER BY CASE when card_set_id = 90000 THEN 2 ELSE 1 END, card_set_id DESC" 
+                    non_exact_sql = non_exact_sql + " ORDER BY CASE WHEN card_set_id = 90000 THEN 2 WHEN card_set_id > 70000 THEN 3 ELSE 1 END, card_set_id DESC" 
 
                     if not group_words:
                         continue

--- a/card_lookup.py
+++ b/card_lookup.py
@@ -49,7 +49,8 @@ def process_card_lookup(matches):
                     for x in range(0, len(group_words) - 1):
                         non_exact_sql = non_exact_sql + " AND card_name LIKE ?"
 
-                    non_exact_sql = non_exact_sql + " ORDER BY card_set_id DESC" # prioritize newer sets
+                    # prioritize newer sets but don't prioritize tokens
+                    non_exact_sql = non_exact_sql + " ORDER BY CASE when card_set_id = 90000 THEN 2 ELSE 1 END, card_set_id DESC" 
 
                     if not group_words:
                         continue

--- a/card_lookup.py
+++ b/card_lookup.py
@@ -50,7 +50,7 @@ def process_card_lookup(matches):
                         non_exact_sql = non_exact_sql + " AND card_name LIKE ?"
 
                     # prioritize newer sets but don't prioritize tokens
-                    non_exact_sql = non_exact_sql + " ORDER BY CASE WHEN card_set_id = 90000 THEN 2 WHEN card_set_id > 70000 THEN 3 ELSE 1 END, card_set_id DESC" 
+                    non_exact_sql = non_exact_sql + " ORDER BY CASE WHEN card_set_id > 70000 THEN 2 ELSE 1 END, card_set_id DESC" 
 
                     if not group_words:
                         continue


### PR DESCRIPTION
card_set_id is 90000 for tokens, which means that tokens get prioritized over all other cards. This change will put token cards to the bottom rows of the result instead of the top.
I apologize for bothering you with the constant PRs, but I think this should be the last one for the day.